### PR TITLE
Let dispatch return dispatcher results

### DIFF
--- a/lib/src/middleware.dart
+++ b/lib/src/middleware.dart
@@ -14,7 +14,7 @@ class DevToolsMiddleware<S> extends MiddlewareClass<DevToolsState<S>> {
   DevToolsMiddleware(this.store, this.appMiddleware);
 
   @override
-  void call(Store<DevToolsState<S>> _, dynamic action, NextDispatcher next) {
+  dynamic call(Store<DevToolsState<S>> _, dynamic action, NextDispatcher next) {
     // Actions are wrapped by the dispatcher as a DevToolsAction. However, the
     // middleware passed into the constructor act on original app actions.
     // Therefore, we must lift the app action out of the DevToolsAction
@@ -30,12 +30,12 @@ class DevToolsMiddleware<S> extends MiddlewareClass<DevToolsState<S>> {
       // actions as DevToolsActions, in the same way as we wrap the initial
       // dispatch call.
       if (action is DevToolsAction) {
-        next(action);
+        return next(action);
       } else {
-        next(new DevToolsAction.perform(action));
+        return next(new DevToolsAction.perform(action));
       }
     };
 
-    appMiddleware(store, actionToDispatch, dispatcher);
+    return appMiddleware(store, actionToDispatch, dispatcher);
   }
 }

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -69,9 +69,9 @@ class DevToolsStore<S> implements Store<S> {
   @override
   dynamic dispatch(dynamic action) {
     if (action is DevToolsAction) {
-      _devToolsStore.dispatch(action);
+      return _devToolsStore.dispatch(action);
     } else {
-      _devToolsStore.dispatch(new DevToolsAction.perform(action));
+      return _devToolsStore.dispatch(new DevToolsAction.perform(action));
     }
   }
 


### PR DESCRIPTION
Hey,

I want to use the [redux_thunk](https://github.com/brianegan/redux_thunk) package in conjunction with the [redux-remote-devtools](https://github.com/MichaelMarner/dart-redux-remote-devtools). The latter depends on this package.

Unfortunately when using the `redux-remote-devtools` package I'm not able to write code that awaits the result of a thunk action:
```dart
await store.dispatch(MyThunkAction());
```
This is however supported with the latest `redux_thunk` package and works with the normal redux store just fine. I figured that the problem lies in not returning the dispatch results. 

That's what this PR attempts to fix. 

I managed to get the `await` behaviour working together with the tiny change in [this PR](https://github.com/MichaelMarner/dart-redux-remote-devtools/pull/22) of the `redux_remote_devtools` package (which just makes sense to merge when this change is merged).

Happy to hear your thoughts on this.

Cheers