### PR TITLE
Migrate to null safety

### DIFF
--- a/lib/src/actions.dart
+++ b/lib/src/actions.dart
@@ -11,7 +11,7 @@
 class DevToolsAction {
   final DevToolsActionTypes type;
   final dynamic appAction;
-  final int position;
+  final int? position;
 
   DevToolsAction._(this.type, this.appAction, this.position);
 

--- a/lib/src/reducer.dart
+++ b/lib/src/reducer.dart
@@ -33,10 +33,10 @@ class DevToolsReducer<S> extends ReducerClass<DevToolsState<S>> {
           devToolsAction,
           addToEnd
               ? state.computedStates
-              : state.computedStates.sublist(0, state.currentPosition + 1),
+              : state.computedStates.sublist(0, state.currentPosition! + 1),
           addToEnd
               ? state.stagedActions
-              : state.stagedActions.sublist(0, state.currentPosition + 1),
+              : state.stagedActions.sublist(0, state.currentPosition! + 1),
           appReducer,
         );
 
@@ -71,13 +71,13 @@ class DevToolsReducer<S> extends ReducerClass<DevToolsState<S>> {
   }
 
   List<S> recomputeStates(List<S> computedStates, List<dynamic> stagedActions) {
-    final recomputedStates = new List<S>(computedStates.length);
+    final recomputedStates = <S>[];
     S currentState = computedStates[0];
 
     for (int i = 0; i < computedStates.length; i++) {
       final dynamic currentAction = stagedActions[i];
       currentState = appReducer(currentState, currentAction);
-      recomputedStates[i] = currentState;
+      recomputedStates.add(currentState);
     }
 
     return recomputedStates;

--- a/lib/src/state.dart
+++ b/lib/src/state.dart
@@ -13,7 +13,7 @@ class DevToolsState<S> {
 
   /// Determines which of the [computedStates] is the current state. This allows
   /// you to skip back and forth in time.
-  final int currentPosition;
+  final int? currentPosition;
 
   /// Create the DevToolsState in the simplest possible way
   DevToolsState(
@@ -53,10 +53,10 @@ class DevToolsState<S> {
 
   /// This is the current state of the application itself. The [DevToolsState]
   /// is simply a wrapper around your application's normal state.
-  S get currentAppState => computedStates[currentPosition];
+  S get currentAppState => computedStates[currentPosition!];
 
   /// The latest action that has been dispatched through the `Store`.
-  dynamic get latestAction => stagedActions[currentPosition];
+  dynamic get latestAction => stagedActions[currentPosition!];
 
   @override
   bool operator ==(Object other) =>

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -38,11 +38,11 @@ import 'package:redux_dev_tools/src/state.dart';
 ///     final store = new DevToolsStore(addReducer);
 class DevToolsStore<S> implements Store<S> {
   final bool _distinct;
-  Store<DevToolsState<S>> _devToolsStore;
+  Store<DevToolsState<S>>? _devToolsStore;
 
   DevToolsStore(
     Reducer<S> reducer, {
-    S initialState,
+    required S initialState,
     List<Middleware<S>> middleware: const [],
     bool syncStream: false,
     bool distinct: false,
@@ -62,33 +62,33 @@ class DevToolsStore<S> implements Store<S> {
     dispatch(new DevToolsAction.init());
   }
 
-  DevToolsState<S> get devToolsState => _devToolsStore.state;
+  DevToolsState<S> get devToolsState => _devToolsStore!.state;
   @override
-  Reducer<S> reducer;
+  late Reducer<S> reducer;
 
   @override
   dynamic dispatch(dynamic action) {
     if (action is DevToolsAction) {
-      return _devToolsStore.dispatch(action);
+      return _devToolsStore!.dispatch(action);
     } else {
-      return _devToolsStore.dispatch(new DevToolsAction.perform(action));
+      return _devToolsStore!.dispatch(new DevToolsAction.perform(action));
     }
   }
 
   @override
   Stream<S> get onChange {
-    final stream = _devToolsStore.onChange
+    final stream = _devToolsStore!.onChange
         .map((devToolsState) => devToolsState.currentAppState);
 
     return _distinct ? stream.distinct() : stream;
   }
 
   @override
-  S get state => _devToolsStore.state.currentAppState;
+  S get state => _devToolsStore!.state.currentAppState;
 
   @override
   Future teardown() async {
-    await _devToolsStore.teardown();
+    await _devToolsStore!.teardown();
     _devToolsStore = null;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,11 +5,11 @@ homepage: https://github.com/brianegan/redux_dev_tools
 author: Brian Egan <brian@brianegan.com>
 
 environment:
-  sdk: '>=2.0.0-dev.28.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  redux: ">=4.0.0 <5.0.0"
+  redux: ^5.0.0
 
 dev_dependencies:
-  coverage: ">=0.13.0 <0.14.0"
-  test: ">=1.0.0 <2.0.0"
+  coverage: ^1.0.1
+  test: ^1.16.8

--- a/test/src/redux_dev_tools_middleware_test.dart
+++ b/test/src/redux_dev_tools_middleware_test.dart
@@ -95,7 +95,7 @@ void main() {
         "async middleware should be able to dispatch follow-up unwrapped actions that travel through the remaining middleware",
         () async {
       int counter = 0;
-      Future<dynamic> fetchComplete;
+      Future<dynamic>? fetchComplete;
       final order = <String>[];
 
       final Middleware<TestState> fetchMiddleware =

--- a/test/src/redux_dev_tools_reducer_test.dart
+++ b/test/src/redux_dev_tools_reducer_test.dart
@@ -63,7 +63,7 @@ class TestReducer extends ReducerClass<TestState> {
 
 void main() {
   group('DevTools Reducers', () {
-    TestReducer testReducer;
+    late TestReducer testReducer;
 
     setUp(() {
       testReducer = new TestReducer();

--- a/test/src/redux_dev_tools_store_test.dart
+++ b/test/src/redux_dev_tools_store_test.dart
@@ -60,7 +60,7 @@ void main() {
         middleware: [MyMiddleware()],
       );
 
-      var returned = store.dispatch(TestAction()) as TestAction;
+      var returned = store.dispatch(TestAction()) as TestAction?;
 
       expect(returned, TypeMatcher<TestAction>());
     });


### PR DESCRIPTION
* Followed the migration instructions
* Ran upgrade tool, applied migration
* Manually edited changes to make code compile and tests pass

The only real change was to Reducer.recomputeState

The empty list constructor is not allowed with null safety enabled. Instead I create an empty, growable list, and add to it.

Closes #5